### PR TITLE
bug fix - removed req(casualPathList()) from pathButtonServer observe…

### DIFF
--- a/R/modules/pathButtons/pathButtonsServer.R
+++ b/R/modules/pathButtons/pathButtonsServer.R
@@ -20,7 +20,6 @@ pathButtonsServer <- function(
       
       # Path buttons
       observe({
-         req(causalPathList())
          current_states <- buttonHighlightStates()
          if (is.null(current_states)) current_states <- list()
          


### PR DESCRIPTION
bug caused orphaned path button that would crash app if user had backdoor paths open with 2 conditioned confounders.